### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server that allows LLM to interact with the block
 
 With these tools, your private keys remain securely stored in your crypto wallet and are never shared with the AI agent when signing messages or sending transactions.
 
+<a href="https://glama.ai/mcp/servers/@Xiawpohr/metamask-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Xiawpohr/metamask-mcp/badge" alt="MetaMask MCP server" />
+</a>
+
 ## Preview
 
 https://github.com/user-attachments/assets/3fe8f20b-4666-4c36-8030-04d3e5d587c7


### PR DESCRIPTION
This PR adds a badge for the [MetaMask MCP](https://glama.ai/mcp/servers/@Xiawpohr/metamask-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Xiawpohr/metamask-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Xiawpohr/metamask-mcp/badge" alt="MetaMask MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.